### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ performs three transforms:
 * restricts output to locations where there is a CG dinucleotide in
 the reference,
 * reports only a C and 5mC counts, using procedures to take into account counts of other forms of cytosine modification (notably 5hmC), and
-* aggregates data across strands. The strand field od the output will be marked as '.' indicating that the strand information has been lost.
+* aggregates data across strands. The strand field of the output will be marked as '.' indicating that the strand information has been lost.
 
 Using this option is equivalent to running with the options:
 


### PR DESCRIPTION
## Summary
- fix minor typo in README

## Testing
- `cargo --version` *(fails: No route to host)*